### PR TITLE
Correct off-by-one on filename

### DIFF
--- a/makeBanlist.py
+++ b/makeBanlist.py
@@ -279,7 +279,7 @@ def generateBanlist(date, name, curated):
 		print("Generating %s Forbidden and Limited List update banlist"%(getDateAsString(date)))
 	sys.stdout.flush()
 	banlistFile = findBanlist(date)
-	setList = getSetList(date)
+	setList = getSetList( findNextSet(date) )
 	cardList = getCardList(setList, banlistFile)
 	printCards(cardList, date, name, curated)
 
@@ -304,7 +304,7 @@ def validateArgs():
 			generatePopularLists()
 			sys.exit()
 		elif len(args[1]) != 10:
-			print("This script requires 2 arguments with format YYYY-MM-DD \"F&L\" to run")
+			print("This script requires 1 date argument with format YYYY-MM-DD to run")
 			sys.exit()
 		elif args[1][4:5] != "-" or args[1][7:8] != "-":
 			print("Use - as the separator for the date")
@@ -321,7 +321,7 @@ def validateArgs():
 		print("This creates a Goat Format banlist that is named Goat Format.conf.lflist")
 		sys.exit()
 	elif length < 2:
-		print("This script requires 2 arguments with format YYYY-MM-DD \"F&L\" to run")
+		print("This script requires 1 date argument with format YYYY-MM-DD to run")
 		sys.exit()
 
 def generateAllLists():
@@ -403,5 +403,20 @@ def generatePopularLists():
 		formatName = ygoformat.get("name")
 		formatDate = ygoformat.get("date")
 		generateBanlist(dateFromString(formatDate), formatName, True)
+
+def findNextSet(date):
+	filenames = getBanlistFileNames()
+	nextDate = date
+	#Run through our filenames and find the next available banlist
+	for filename in filenames:
+		if ( dateFromString(filename) > date):
+			nextDate = dateFromString(filename)
+			break
+	#If our date has stayed the same from start to end, we are using the lastest list.
+	#If our list is in the future, then just set it to today.
+	if (nextDate == date or nextDate > date.today()):
+		nextDate = date.today()
+	print(F"Calculated next date to be {nextDate}")
+	return nextDate
 
 validateArgs()

--- a/makeBanlist.py
+++ b/makeBanlist.py
@@ -321,7 +321,7 @@ def validateArgs():
 		print("This creates a Goat Format banlist that is named Goat Format.conf.lflist")
 		sys.exit()
 	elif length < 2:
-		print("This script requires 2 argument with format YYYY-MM-DD \"F&L\" to run")
+		print("This script requires 2 arguments with format YYYY-MM-DD \"F&L\" to run")
 		sys.exit()
 
 def generateAllLists():

--- a/makeBanlist.py
+++ b/makeBanlist.py
@@ -159,11 +159,16 @@ def getSetList(date):
 def findBanlist(date):
 	filenames = getBanlistFileNames()
 	lastbanlist = "2002-03-01.json"
+	
 	for filename in filenames:
 		banlistDate = dateFromString(filename)
-		if (banlistDate < date):
-			lastbanlist = filename
+		lastbanlist = filename
+		if (banlistDate >= date):
+			break
 
+	if(banlistDate != date):
+		print("Couldn't find banlist! Check that it is available in the /banlists folder!")
+		sys.exit()
 	return lastbanlist
 
 def getBanlistFileNames():
@@ -299,7 +304,7 @@ def validateArgs():
 			generatePopularLists()
 			sys.exit()
 		elif len(args[1]) != 10:
-			print("This script requires 1 date argument with format YYYY-MM-DD to run")
+			print("This script requires 2 arguments with format YYYY-MM-DD \"F&L\" to run")
 			sys.exit()
 		elif args[1][4:5] != "-" or args[1][7:8] != "-":
 			print("Use - as the separator for the date")
@@ -316,7 +321,7 @@ def validateArgs():
 		print("This creates a Goat Format banlist that is named Goat Format.conf.lflist")
 		sys.exit()
 	elif length < 2:
-		print("This script requires 1 date argument with format YYYY-MM-DD to run")
+		print("This script requires 2 argument with format YYYY-MM-DD \"F&L\" to run")
 		sys.exit()
 
 def generateAllLists():


### PR DESCRIPTION
Previously, the loop searching for a filename would produce an off-by-one error, leaving you with an incorrect banlist.

For example, when searching for banlist `2015-04-01`, you would get the banlist for `2014-10-01` instead (look at Tour Guide from the Underworld, for example, as compared to the banlist: https://web.archive.org/web/20151004063731/http://www.yugioh-card.com/en/limited/April_2015.html

I've corrected this behavior to fetch the correct banlist, however I have also changed the behavior to give the user a warning and quit gracefully rather than to generate an incorrect banlist in the case that they enter an incorrect value. ~~Also, I've added to the help message that you need not only a date but also the "F&L" string in order to generate a lflist file.~~ reverted